### PR TITLE
Add missing version annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.sonatype.nexus.plugins</groupId>
         <artifactId>nexus-plugins</artifactId>
-        <version>3.68.1-02</version>
+        <version>3.70.1-02</version>
     </parent>
 
     <groupId>com.github.tumbl3w33d</groupId>
@@ -42,8 +42,8 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -73,7 +73,13 @@
         </dependency>
         <dependency>
             <groupId>org.sonatype.nexus</groupId>
+            <artifactId>nexus-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.sonatype.nexus</groupId>
             <artifactId>nexus-rest</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.sonatype.nexus</groupId>

--- a/src/main/java/com/github/tumbl3w33d/OAuth2ProxyApiTokenInvalidateTaskDescriptor.java
+++ b/src/main/java/com/github/tumbl3w33d/OAuth2ProxyApiTokenInvalidateTaskDescriptor.java
@@ -4,10 +4,12 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.sonatype.nexus.common.upgrade.AvailabilityVersion;
 import org.sonatype.nexus.formfields.FormField;
 import org.sonatype.nexus.formfields.NumberTextFormField;
 import org.sonatype.nexus.scheduling.TaskDescriptorSupport;
 
+@AvailabilityVersion(from = "1.0")
 @Named
 @Singleton
 public class OAuth2ProxyApiTokenInvalidateTaskDescriptor
@@ -22,17 +24,17 @@ public class OAuth2ProxyApiTokenInvalidateTaskDescriptor
     "After this duration the API token will be overwritten and the user must renew it interactively."
     ,
     FormField.MANDATORY).withMinimumValue(1).withInitialValue(30);
-    
+
     @Inject
     public OAuth2ProxyApiTokenInvalidateTaskDescriptor() {
-        super(TYPE_ID, OAuth2ProxyApiTokenInvalidateTask.class,       "OAuth2 Proxy API token invalidator",
+        super(TYPE_ID, OAuth2ProxyApiTokenInvalidateTask.class, "OAuth2 Proxy API token invalidator",
         TaskDescriptorSupport.VISIBLE, TaskDescriptorSupport.EXPOSED,
         TaskDescriptorSupport.REQUEST_RECOVERY, new FormField[] { field });
     }
-    
+
     @Override
     public boolean allowConcurrentRun() {
         return false;
     }
-    
+
 }

--- a/src/main/java/com/github/tumbl3w33d/users/OAuth2ProxyUserManager.java
+++ b/src/main/java/com/github/tumbl3w33d/users/OAuth2ProxyUserManager.java
@@ -224,4 +224,8 @@ public class OAuth2ProxyUserManager extends AbstractUserManager {
         return userStore.getApiToken(principal);
     }
 
+    @Override
+    public boolean isConfigured() {
+        return true;
+    }
 }


### PR DESCRIPTION
Update parent config in `pom.xml` to use v3.70. Later versions are missing some dependencies available on Maven central!

Add impl for `isConfigured` returning `true`. Do you agree with that @tumbl3w33d?

Fixes #11