### PR TITLE
Add missing Javascript to Karaf bundle

### DIFF
--- a/src/frontend/webpack.config.js
+++ b/src/frontend/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     entry: './src/frontend/src',
     output: {
         filename: 'nexus-oauth2-proxy-bundle.js',
-        path: path.resolve(__dirname, 'target', 'classes', 'static')
+        path: path.resolve(__dirname, '..', '..', 'target', 'classes', 'static')
     },
     module: {
         rules: [


### PR DESCRIPTION
I have to apologize for not testing the last release on a clean setup.
Because of changing the location of the webpack config file the Javascript output was not covered by the Karaf bundling.