### PR TITLE
Allow configuring max age and expiry notifications for login tokens

### DIFF
--- a/src/main/java/com/github/tumbl3w33d/OAuth2ProxyApiTokenInvalidateTask.java
+++ b/src/main/java/com/github/tumbl3w33d/OAuth2ProxyApiTokenInvalidateTask.java
@@ -5,88 +5,164 @@ import static org.sonatype.nexus.logging.task.TaskLogType.NEXUS_LOG_ONLY;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.apache.commons.mail.EmailException;
+import org.apache.commons.mail.SimpleEmail;
+import org.sonatype.nexus.common.app.BaseUrlHolder;
+import org.sonatype.nexus.email.EmailManager;
 import org.sonatype.nexus.logging.task.TaskLogging;
 import org.sonatype.nexus.scheduling.Cancelable;
 import org.sonatype.nexus.scheduling.TaskSupport;
-import org.sonatype.nexus.security.user.UserManager;
+import org.sonatype.nexus.security.SecuritySystem;
+import org.sonatype.nexus.security.user.User;
 import org.sonatype.nexus.security.user.UserNotFoundException;
 
 import com.github.tumbl3w33d.h2.OAuth2ProxyLoginRecordStore;
+import com.github.tumbl3w33d.h2.OAuth2ProxyTokenInfoStore;
 import com.github.tumbl3w33d.users.OAuth2ProxyUserManager;
 import com.github.tumbl3w33d.users.db.OAuth2ProxyLoginRecord;
+import com.github.tumbl3w33d.users.db.OAuth2ProxyTokenInfo;
 
 @Named
 @TaskLogging(NEXUS_LOG_ONLY)
 public class OAuth2ProxyApiTokenInvalidateTask extends TaskSupport implements Cancelable {
 
     private final OAuth2ProxyLoginRecordStore loginRecordStore;
-
+    private final OAuth2ProxyTokenInfoStore tokenInfoStore;
     private final OAuth2ProxyUserManager userManager;
+    private final SecuritySystem securitySystem;
+    private final EmailManager mailManager;
 
     @Inject
     public OAuth2ProxyApiTokenInvalidateTask(@Named OAuth2ProxyLoginRecordStore loginRecordStore,
-            final List<UserManager> userManagers, final OAuth2ProxyUserManager userManager) {
-
+            @Named OAuth2ProxyTokenInfoStore tokenInfoStore, @Named OAuth2ProxyUserManager userManager,
+            SecuritySystem securitySystem, EmailManager mailManager) {
         this.loginRecordStore = loginRecordStore;
+        this.tokenInfoStore = tokenInfoStore;
         this.userManager = userManager;
-    }
-
-    private void resetApiToken(String userId) {
-        try {
-            userManager.changePassword(userId, OAuth2ProxyRealm.generateSecureRandomString(32));
-            log.debug("API token reset for user {} succeeded", userId);
-        } catch (UserNotFoundException e) {
-            log.error("Unable to reset API token of user {} - {}", userId, e);
-        }
+        this.securitySystem = securitySystem;
+        this.mailManager = mailManager;
     }
 
     @Override
     protected Void execute() throws Exception {
+        Map<String, OAuth2ProxyLoginRecord> loginRecords = loginRecordStore.getAllLoginRecords();
+        Map<String, OAuth2ProxyTokenInfo> tokenInfos = tokenInfoStore.getAllTokenInfos();
 
-        Set<OAuth2ProxyLoginRecord> loginRecords = loginRecordStore.getAllLoginRecords();
-
-        if (loginRecords.isEmpty()) {
-            log.debug("No login records found, nothing to do");
+        if (loginRecords.isEmpty() && tokenInfos.isEmpty()) {
+            log.debug("No records found, nothing to do");
             return null;
         }
 
-        for (OAuth2ProxyLoginRecord loginRecord : loginRecords) {
-            String userId = loginRecord.getId();
-            Timestamp lastLoginDate = loginRecord.getLastLogin();
+        int configuredIdleExpiration = getConfiguration().getInteger(
+                OAuth2ProxyApiTokenInvalidateTaskDescriptor.CONFIG_IDLE_EXPIRY,
+                OAuth2ProxyApiTokenInvalidateTaskDescriptor.CONFIG_IDLE_EXPIRY_DEFAULT);
 
-            Instant lastLoginInstant = lastLoginDate.toInstant();
-            Instant nowInstant = Instant.now();
+        int configuredMaxTokenAge = getConfiguration().getInteger(
+                OAuth2ProxyApiTokenInvalidateTaskDescriptor.CONFIG_AGE,
+                OAuth2ProxyApiTokenInvalidateTaskDescriptor.CONFIG_AGE_DEFAULT);
 
-            log.debug("Last known login for {} was {}", userId,
-                    OAuth2ProxyRealm.formatDateString(lastLoginDate));
+        boolean notify = getConfiguration().getBoolean(OAuth2ProxyApiTokenInvalidateTaskDescriptor.NOTIFY,
+                OAuth2ProxyApiTokenInvalidateTaskDescriptor.NOTIFY_DEFAULT);
 
-            long timePassed = ChronoUnit.DAYS.between(lastLoginInstant, nowInstant);
-
-            int configuredDuration = getConfiguration()
-                    .getInteger(OAuth2ProxyApiTokenInvalidateTaskDescriptor.CONFIG_EXPIRY, 1);
-
-            log.debug("Time passed since login: {} - configured maximum: {}", timePassed,
-                    configuredDuration);
-
-            if (timePassed >= configuredDuration) {
-                resetApiToken(userId);
-                log.info("Reset api token of user {} because they did not show up for a while",
-                        userId);
+        Set<String> userIds = new HashSet<>(loginRecords.size());
+        userIds.addAll(loginRecords.keySet());
+        userIds.addAll(tokenInfos.keySet());
+        for (String userId : userIds) {
+            if ("admin".equals(userId)) {
+                // never reset the admin "token" as it would overwrite the password, possibly locking people out of nexus
+                // when the task would run before OIDC setup is completed
+                continue;
             }
+
+            if (isUserIdleTimeExpired(userId, loginRecords.get(userId), configuredIdleExpiration)
+                    || isTokenLifespanExpired(userId, tokenInfos.get(userId), configuredMaxTokenAge)) {
+                resetApiToken(userId, notify);
+                log.info("API token of user {} has been reset", userId);
+            }
+
+        }
+        return null;
+    }
+
+    private boolean isUserIdleTimeExpired(String userId, OAuth2ProxyLoginRecord loginRecord, int configuredIdleTime) {
+        if (configuredIdleTime <= 0) {
+            return false;
         }
 
-        return null;
+        Timestamp lastLoginDate = loginRecord.getLastLogin();
+        log.debug("Last known login for {} was {}", userId, OAuth2ProxyRealm.formatDateString(lastLoginDate));
+        long timePassed = ChronoUnit.DAYS.between(lastLoginDate.toInstant(), Instant.now());
+        log.debug("Time passed since login: {} - configured maximum: {}", timePassed, configuredIdleTime);
+        if (timePassed >= configuredIdleTime) {
+            log.debug("Idle time expired for {}", userId);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isTokenLifespanExpired(String userId, OAuth2ProxyTokenInfo tokenInfo, int configuredMaxTokenAge) {
+        if (configuredMaxTokenAge <= 0) {
+            return false;
+        }
+
+        Timestamp tokenCreationDate = tokenInfo.getTokenCreation();
+        log.debug("API token for {} was created at {}", userId, OAuth2ProxyRealm.formatDateString(tokenCreationDate));
+        long timePassed = ChronoUnit.DAYS.between(tokenCreationDate.toInstant(), Instant.now());
+        log.debug("Time passed since token creation: {} - configured maximum: {}", timePassed, configuredMaxTokenAge);
+        if (timePassed >= configuredMaxTokenAge) {
+            log.debug("Token lifespan expired for user {}", userId);
+            return true;
+        }
+        return false;
     }
 
     @Override
     public String getMessage() {
         return "Invalidate OAuth2 Proxy API tokens of users who did not show up for a while";
+    }
+
+    private void resetApiToken(String userId, boolean notify) {
+        try {
+            securitySystem.changePassword(userId, OAuth2ProxyRealm.generateSecureRandomString(32));
+            log.debug("API token reset for user {} succeeded", userId);
+            if (notify) {
+                sendMail(userId);
+            }
+        } catch (UserNotFoundException e) {
+            log.error("Unable to reset API token of user {}", userId);
+            log.debug("Unable to reset API token of user {}", userId, e);
+        }
+    }
+
+    private void sendMail(String userId) throws UserNotFoundException {
+        if (mailManager.getConfiguration().isEnabled()) {
+            User user = userManager.getUser(userId);
+            String to = user.getEmailAddress();
+            try {
+                SimpleEmail mail = new SimpleEmail();
+                mail.addTo(to);
+                if (BaseUrlHolder.isSet()) {
+                    mail.setMsg("Your OAuth2 Proxy API Token on " + BaseUrlHolder.get()
+                            + " has been invalidated because of inactivity or expired token lifespan");
+                } else {
+                    mail.setMsg(
+                            "Your OAuth2 Proxy API Token has been invalidated because of inactivity or expired token lifespan");
+                }
+                mailManager.send(mail);
+            } catch (EmailException e) {
+                log.warn("Failed to send notification email about oauth2 API token reset to user " + user.getName());
+                log.debug("Failed to send notification email", e);
+            }
+        } else {
+            log.warn("Sending token invalidation notifications is enabled, but no mail server is configured in Nexus");
+        }
     }
 
 }

--- a/src/main/java/com/github/tumbl3w33d/OAuth2ProxyApiTokenInvalidateTaskDescriptor.java
+++ b/src/main/java/com/github/tumbl3w33d/OAuth2ProxyApiTokenInvalidateTaskDescriptor.java
@@ -5,6 +5,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.sonatype.nexus.common.upgrade.AvailabilityVersion;
+import org.sonatype.nexus.formfields.CheckboxFormField;
 import org.sonatype.nexus.formfields.FormField;
 import org.sonatype.nexus.formfields.NumberTextFormField;
 import org.sonatype.nexus.scheduling.TaskDescriptorSupport;
@@ -12,22 +13,43 @@ import org.sonatype.nexus.scheduling.TaskDescriptorSupport;
 @AvailabilityVersion(from = "1.0")
 @Named
 @Singleton
-public class OAuth2ProxyApiTokenInvalidateTaskDescriptor
-        extends TaskDescriptorSupport {
+public class OAuth2ProxyApiTokenInvalidateTaskDescriptor extends TaskDescriptorSupport {
 
     public static final String TYPE_ID = "oauth2-proxy-api-token.cleanup";
 
-    public static final String CONFIG_EXPIRY = TYPE_ID + "-expiry";
-    private static final NumberTextFormField field = new NumberTextFormField(CONFIG_EXPIRY,
-            "Expiration in days",
-            "After this duration the API token will be overwritten and the user must renew it interactively.",
-            FormField.MANDATORY).withMinimumValue(1).withInitialValue(30);
+    public static final String CONFIG_IDLE_EXPIRY = TYPE_ID + "-expiry";
+    public static final int CONFIG_IDLE_EXPIRY_DEFAULT = 30;
+    private static final NumberTextFormField maxIdleAge = new NumberTextFormField(CONFIG_IDLE_EXPIRY, //
+            "User idle time in days", //
+            "After the user has been inactive for this amount of days the API token will be overwritten and the user must renew it interactively. Setting this to 0 or a negative value disables max idle time entirely. Default is "
+                    + CONFIG_IDLE_EXPIRY_DEFAULT + " days.",
+            FormField.MANDATORY)//
+            .withMinimumValue(1)//
+            .withInitialValue(CONFIG_IDLE_EXPIRY_DEFAULT);
+
+    public static final String CONFIG_AGE = TYPE_ID + "-max-age";
+    public static final int CONFIG_AGE_DEFAULT = -1;
+    private static final NumberTextFormField maxAge = new NumberTextFormField(CONFIG_AGE, //
+            "Max token age in days", //
+            "After this amount of days the API token will be overwritten and the user must renew it interactively. Setting this to 0 or a negative value disables max token age entirely. Default is "
+                    + CONFIG_AGE_DEFAULT + " days.",
+            FormField.MANDATORY)//
+            .withInitialValue(CONFIG_AGE_DEFAULT);
+
+    public static final String NOTIFY = TYPE_ID + "-notify";
+    public static final Boolean NOTIFY_DEFAULT = false;
+    private static final CheckboxFormField notify = new CheckboxFormField(NOTIFY, //
+            "Send Email on token invalidation", //
+            "Defines whether an email is send to the affected user if their API token is invalidated automatically based on any condition. Default is "
+                    + NOTIFY_DEFAULT,
+            FormField.OPTIONAL)//
+            .withInitialValue(NOTIFY_DEFAULT);
 
     @Inject
     public OAuth2ProxyApiTokenInvalidateTaskDescriptor() {
         super(TYPE_ID, OAuth2ProxyApiTokenInvalidateTask.class, "OAuth2 Proxy API token invalidator",
-                TaskDescriptorSupport.VISIBLE, TaskDescriptorSupport.EXPOSED,
-                TaskDescriptorSupport.REQUEST_RECOVERY, new FormField[] { field });
+                TaskDescriptorSupport.VISIBLE, TaskDescriptorSupport.EXPOSED, TaskDescriptorSupport.REQUEST_RECOVERY,
+                new FormField[] { maxIdleAge, maxAge, notify });
     }
 
     @Override

--- a/src/main/java/com/github/tumbl3w33d/h2/OAuth2ProxyStores.java
+++ b/src/main/java/com/github/tumbl3w33d/h2/OAuth2ProxyStores.java
@@ -32,4 +32,8 @@ public class OAuth2ProxyStores {
     public static OAuth2ProxyLoginRecordDAO loginRecordDAO() {
         return dao(OAuth2ProxyLoginRecordDAO.class);
     }
+
+    public static OAuth2ProxyTokenInfoDAO tokenInfoDAO() {
+        return dao(OAuth2ProxyTokenInfoDAO.class);
+    }
 }

--- a/src/main/java/com/github/tumbl3w33d/h2/OAuth2ProxyTokenInfoDAO.java
+++ b/src/main/java/com/github/tumbl3w33d/h2/OAuth2ProxyTokenInfoDAO.java
@@ -1,0 +1,9 @@
+package com.github.tumbl3w33d.h2;
+
+import org.sonatype.nexus.datastore.api.IdentifiedDataAccess;
+
+import com.github.tumbl3w33d.users.db.OAuth2ProxyTokenInfo;
+
+public interface OAuth2ProxyTokenInfoDAO extends IdentifiedDataAccess<OAuth2ProxyTokenInfo> {
+
+}

--- a/src/main/java/com/github/tumbl3w33d/h2/OAuth2ProxyTokenInfoStore.java
+++ b/src/main/java/com/github/tumbl3w33d/h2/OAuth2ProxyTokenInfoStore.java
@@ -1,0 +1,75 @@
+package com.github.tumbl3w33d.h2;
+
+import static com.github.tumbl3w33d.h2.OAuth2ProxyStores.tokenInfoDAO;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport;
+import org.sonatype.nexus.datastore.api.DataSession;
+import org.sonatype.nexus.datastore.api.DataSessionSupplier;
+import org.sonatype.nexus.transaction.Transactional;
+import org.sonatype.nexus.transaction.TransactionalStore;
+
+import com.github.tumbl3w33d.users.db.OAuth2ProxyTokenInfo;
+
+@Named("mybatis")
+@Singleton
+public class OAuth2ProxyTokenInfoStore extends StateGuardLifecycleSupport
+        implements TransactionalStore<DataSession<?>> {
+
+    private final DataSessionSupplier sessionSupplier;
+
+    @Inject
+    public OAuth2ProxyTokenInfoStore(final DataSessionSupplier sessionSupplier) {
+        this.sessionSupplier = sessionSupplier;
+    }
+
+    @Override
+    public DataSession<?> openSession() {
+        return OAuth2ProxyStores.openSession(sessionSupplier);
+    }
+
+    @Transactional
+    public Map<String, OAuth2ProxyTokenInfo> getAllTokenInfos() {
+        return Collections.unmodifiableMap(StreamSupport.stream(tokenInfoDAO().browse().spliterator(), false)
+                .collect(Collectors.toMap(OAuth2ProxyTokenInfo::getId, Function.identity())));
+    }
+
+    @Transactional
+    public Optional<OAuth2ProxyTokenInfo> getTokenInfo(String userId) {
+        log.trace("call to getTokenInfo with userId {}", userId);
+
+        try {
+            return tokenInfoDAO().read(userId);
+        } catch (Exception e) {
+            log.error("unable to retrieve token record for {} - {}", userId, e);
+            throw e;
+        }
+    }
+
+    @Transactional
+    public void createTokenInfo(String userId) {
+        log.trace("call to createTokenInfo with userId {}", userId);
+        try {
+            tokenInfoDAO().create(OAuth2ProxyTokenInfo.of(userId));
+        } catch (Exception e) {
+            log.error("unable to create token record for {} - {}", userId, e);
+            throw e;
+        }
+    }
+
+    @Transactional
+    public void updateTokenInfo(String userId) {
+        tokenInfoDAO().update(OAuth2ProxyTokenInfo.of(userId));
+    }
+
+}

--- a/src/main/java/com/github/tumbl3w33d/users/OAuth2ProxyUserManager.java
+++ b/src/main/java/com/github/tumbl3w33d/users/OAuth2ProxyUserManager.java
@@ -19,6 +19,7 @@ import org.sonatype.nexus.security.user.UserSearchCriteria;
 import org.sonatype.nexus.security.user.UserStatus;
 
 import com.github.tumbl3w33d.OAuth2ProxyRealm;
+import com.github.tumbl3w33d.h2.OAuth2ProxyTokenInfoStore;
 import com.github.tumbl3w33d.h2.OAuth2ProxyUserStore;
 import com.github.tumbl3w33d.users.db.OAuth2ProxyUser;
 
@@ -31,10 +32,13 @@ public class OAuth2ProxyUserManager extends AbstractUserManager {
     public static final String SOURCE = "OAuth2Proxy";
 
     private final OAuth2ProxyUserStore userStore;
+    private final OAuth2ProxyTokenInfoStore tokenInfoStore;
 
     @Inject
-    public OAuth2ProxyUserManager(final OAuth2ProxyUserStore userStore) {
+    public OAuth2ProxyUserManager(final OAuth2ProxyUserStore userStore,
+            @Named final OAuth2ProxyTokenInfoStore tokenInfoStore) {
         this.userStore = userStore;
+        this.tokenInfoStore = tokenInfoStore;
     }
 
     @Override
@@ -179,6 +183,7 @@ public class OAuth2ProxyUserManager extends AbstractUserManager {
 
         if (maybeUserToUpdate.isPresent()) {
             userStore.updateUserApiToken(userId, newPassword);
+            tokenInfoStore.updateTokenInfo(userId);
         } else {
             log.warn("could not retrieve user {} for changing password", userId);
         }

--- a/src/main/java/com/github/tumbl3w33d/users/db/OAuth2ProxyTokenInfo.java
+++ b/src/main/java/com/github/tumbl3w33d/users/db/OAuth2ProxyTokenInfo.java
@@ -1,0 +1,42 @@
+package com.github.tumbl3w33d.users.db;
+
+import java.io.Serializable;
+import java.sql.Timestamp;
+
+import org.joda.time.Instant;
+import org.sonatype.nexus.common.entity.AbstractEntity;
+import org.sonatype.nexus.common.entity.HasStringId;
+
+public class OAuth2ProxyTokenInfo extends AbstractEntity implements Serializable, HasStringId {
+
+    private static final long serialVersionUID = -2052302452536776751L;
+
+    private String userId;
+    private Timestamp tokenCreation;
+
+    public Timestamp getTokenCreation() {
+        return tokenCreation;
+    }
+
+    public void setTokenCreation(Timestamp tokenCreation) {
+        this.tokenCreation = tokenCreation;
+    }
+
+    @Override
+    public String getId() {
+        return this.userId;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.userId = id;
+    }
+
+    public static OAuth2ProxyTokenInfo of(String userId) {
+        OAuth2ProxyTokenInfo newRecord = new OAuth2ProxyTokenInfo();
+        newRecord.setId(userId);
+        newRecord.setTokenCreation(new Timestamp(Instant.now().getMillis()));
+        return newRecord;
+    }
+
+}

--- a/src/main/resources/com/github/tumbl3w33d/h2/OAuth2ProxyTokenInfoDAO.xml
+++ b/src/main/resources/com/github/tumbl3w33d/h2/OAuth2ProxyTokenInfoDAO.xml
@@ -1,0 +1,49 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.github.tumbl3w33d.h2.OAuth2ProxyTokenInfoDAO">
+
+    <resultMap id="OAuth2ProxyTokenInfoMap" type="com.github.tumbl3w33d.users.db.OAuth2ProxyTokenInfo">
+        <id property="userId" column="userId"/>
+        <result property="tokenCreation" column="tokenCreation"/>
+    </resultMap>
+
+    <update id="createSchema">
+        CREATE TABLE IF NOT EXISTS oauth2_proxy_token_info (
+            userId VARCHAR(255) NOT NULL,
+            tokenCreation TIMESTAMP NOT NULL,
+            PRIMARY KEY (userId)
+        );
+
+        -- Seed this table by assuming the last login was when the token was created. While not correct, this is better than nothing        
+        INSERT INTO oauth2_proxy_token_info (userId, tokenCreation)
+        SELECT userId, lastLogin FROM oauth2_proxy_login_record;
+        
+    </update>
+
+    <insert id="create" parameterType="com.github.tumbl3w33d.users.db.OAuth2ProxyTokenInfo">
+        INSERT INTO oauth2_proxy_token_info (userId, tokenCreation)
+        VALUES (#{userId, jdbcType=VARCHAR}, #{tokenCreation, jdbcType=TIMESTAMP})
+    </insert>
+
+    <update id="update" parameterType="com.github.tumbl3w33d.users.db.OAuth2ProxyTokenInfo">
+        UPDATE oauth2_proxy_token_info
+        SET tokenCreation = #{tokenCreation, jdbcType=TIMESTAMP}
+        WHERE userId = #{userId, jdbcType=VARCHAR}
+    </update>
+
+    <select id="read" resultMap="OAuth2ProxyTokenInfoMap">
+        SELECT userId, tokenCreation
+        FROM oauth2_proxy_token_info
+        WHERE userId = #{userId}
+    </select>
+
+    <delete id="delete" parameterType="String">
+        DELETE FROM oauth2_proxy_token_info
+        WHERE userId = #{userId}
+    </delete>
+
+    <select id="browse" resultMap="OAuth2ProxyTokenInfoMap">
+        SELECT userId, tokenCreation
+        FROM oauth2_proxy_token_info
+    </select>
+
+</mapper>

--- a/src/test/java/com/github/tumbl3w33d/users/OAuth2ProxyUserManagerTest.java
+++ b/src/test/java/com/github/tumbl3w33d/users/OAuth2ProxyUserManagerTest.java
@@ -20,6 +20,7 @@ import org.sonatype.nexus.security.user.UserNotFoundException;
 import org.sonatype.nexus.security.user.UserSearchCriteria;
 import org.sonatype.nexus.security.user.UserStatus;
 
+import com.github.tumbl3w33d.h2.OAuth2ProxyTokenInfoStore;
 import com.github.tumbl3w33d.h2.OAuth2ProxyUserStore;
 import com.github.tumbl3w33d.users.db.OAuth2ProxyUser;
 import com.google.common.collect.ImmutableSet;
@@ -119,7 +120,8 @@ public class OAuth2ProxyUserManagerTest {
         User exampleUser = OAuth2ProxyUserManager.createUserObject("test.user",
                 "test.user@example.com");
         Mockito.when(userStore.getUser(anyString())).thenReturn(Optional.of(exampleUser));
-        OAuth2ProxyUserManager userManager = new OAuth2ProxyUserManager(userStore);
+        OAuth2ProxyUserManager userManager = new OAuth2ProxyUserManager(userStore,
+                Mockito.mock(OAuth2ProxyTokenInfoStore.class));
 
         assertDoesNotThrow(() -> {
             User user = userManager.getUser(exampleUser.getUserId());
@@ -134,7 +136,8 @@ public class OAuth2ProxyUserManagerTest {
         User exampleUser = OAuth2ProxyUserManager.createUserObject("test.user",
                 "test.user@example.com");
         Mockito.when(userStore.getUser(anyString())).thenReturn(Optional.empty());
-        OAuth2ProxyUserManager userManager = new OAuth2ProxyUserManager(userStore);
+        OAuth2ProxyUserManager userManager = new OAuth2ProxyUserManager(userStore,
+                Mockito.mock(OAuth2ProxyTokenInfoStore.class));
 
         assertThrows(UserNotFoundException.class,
                 () -> userManager.getUser(exampleUser.getUserId()));
@@ -146,7 +149,8 @@ public class OAuth2ProxyUserManagerTest {
         User exampleUser = OAuth2ProxyUserManager.createUserObject("test.user",
                 "test.user@example.com");
         Mockito.when(userStore.getUser(anyString())).thenReturn(Optional.of(exampleUser));
-        OAuth2ProxyUserManager userManager = new OAuth2ProxyUserManager(userStore);
+        OAuth2ProxyUserManager userManager = new OAuth2ProxyUserManager(userStore,
+                Mockito.mock(OAuth2ProxyTokenInfoStore.class));
 
         assertDoesNotThrow(() -> {
             User user = userManager.getUser(exampleUser.getUserId(),
@@ -165,7 +169,8 @@ public class OAuth2ProxyUserManagerTest {
                 "test.user2@example.com");
         ImmutableSet<User> testUsers = ImmutableSet.of(exampleUser1, exampleUser2);
         Mockito.when(userStore.getAllUsers()).thenReturn(testUsers);
-        OAuth2ProxyUserManager userManager = new OAuth2ProxyUserManager(userStore);
+        OAuth2ProxyUserManager userManager = new OAuth2ProxyUserManager(userStore,
+                Mockito.mock(OAuth2ProxyTokenInfoStore.class));
 
         assertEquals(ImmutableSet.of("test.user1", "test.user2"),
                 userManager.listUserIds());
@@ -180,7 +185,8 @@ public class OAuth2ProxyUserManagerTest {
                 "test.user2@example.com");
         ImmutableSet<User> testUsers = ImmutableSet.of(exampleUser1, exampleUser2);
         Mockito.when(userStore.getAllUsers()).thenReturn(testUsers);
-        OAuth2ProxyUserManager userManager = new OAuth2ProxyUserManager(userStore);
+        OAuth2ProxyUserManager userManager = new OAuth2ProxyUserManager(userStore,
+                Mockito.mock(OAuth2ProxyTokenInfoStore.class));
 
         assertEquals(testUsers, userManager.listUsers());
     }
@@ -191,7 +197,8 @@ public class OAuth2ProxyUserManagerTest {
         User exampleUser = OAuth2ProxyUserManager.createUserObject("test.user",
                 "test.user@example.com");
         Mockito.when(userStore.getAllUsers()).thenReturn(ImmutableSet.of(exampleUser));
-        OAuth2ProxyUserManager userManager = new OAuth2ProxyUserManager(userStore);
+        OAuth2ProxyUserManager userManager = new OAuth2ProxyUserManager(userStore,
+                Mockito.mock(OAuth2ProxyTokenInfoStore.class));
 
         Set<User> searchResult = userManager.searchUsers(new UserSearchCriteria("test.user"));
         assertTrue(searchResult.size() == 1);
@@ -250,7 +257,8 @@ public class OAuth2ProxyUserManagerTest {
             userStore = Mockito.mock(OAuth2ProxyUserStore.class);
         }
 
-        OAuth2ProxyUserManager userManager = new OAuth2ProxyUserManager(userStore);
+        OAuth2ProxyUserManager userManager = new OAuth2ProxyUserManager(userStore,
+                Mockito.mock(OAuth2ProxyTokenInfoStore.class));
         return userManager;
     }
 }


### PR DESCRIPTION
- Trying to enforce maximum security, access tokens should not be valid forever.
- It is possible to implement automatic token rotation by directly accessing the REST service similar to what the UI does.
- Enabling max token age invalidation (which is optional and off by default for backwards compatibility) means a lot more invalidation happen.
- To help users troubleshoot 401 errors when contacting nexus, a possibility to notify users via email when their tokens expire was introduced.
- This is entirely optional and will only work if Nexus has a mail server configured via default Sonatype means.
- Leveraging OAuth2 Proxys behaviour and correct reverse proxy configuration, this allows to use API tokens like OIDC access tokens with very limited lifespan, where renewing the API token requires full OIDC login, potentially including 2FA, Passkeys or whatever login method is configured.
- If everything is configured correctly, it is not possible to renew the API token with an existing API token, but only with full OAuth2 Proxy login, further strengthening security