### PR TITLE
Make auth headers configurable and try to better parse first name and surname

### DIFF
--- a/src/main/java/com/github/tumbl3w33d/OAuth2ProxyHeaderAuthTokenFactory.java
+++ b/src/main/java/com/github/tumbl3w33d/OAuth2ProxyHeaderAuthTokenFactory.java
@@ -24,11 +24,11 @@ public class OAuth2ProxyHeaderAuthTokenFactory extends HttpHeaderAuthenticationT
 
     private final Logger logger = LoggerFactory.getLogger(OAuth2ProxyHeaderAuthTokenFactory.class);
 
-    static final String X_FORWARDED_USER = "X-Forwarded-User";
-    static final String X_FORWARDED_PREFERRED_USERNAME = "X-Forwarded-Preferred-Username";
-    static final String X_FORWARDED_EMAIL = "X-Forwarded-Email";
-    static final String X_FORWARDED_ACCESS_TOKEN = "X-Forwarded-Access-Token";
-    static final String X_FORWARDED_GROUPS = "X-Forwarded-Groups";
+    static final String X_FORWARDED_USER = System.getenv().getOrDefault("OAUTH2_PROXY_HEADER_USER", "X-Forwarded-User");
+    static final String X_FORWARDED_PREFERRED_USERNAME = System.getenv().getOrDefault("OAUTH2_PROXY_HEADER_PREFERRED_USERNAME", "X-Forwarded-Preferred-Username");
+    static final String X_FORWARDED_EMAIL = System.getenv().getOrDefault("OAUTH2_PROXY_HEADER_EMAIL", "X-Forwarded-Email");
+    static final String X_FORWARDED_ACCESS_TOKEN = System.getenv().getOrDefault("OAUTH2_PROXY_HEADER_ACCESS_TOKEN", "X-Forwarded-Access-Token");
+    static final String X_FORWARDED_GROUPS = System.getenv().getOrDefault("OAUTH2_PROXY_HEADER_GROUPS", "X-Forwarded-Groups");
 
     static final List<String> OAUTH2_PROXY_HEADERS = Collections.unmodifiableList(Arrays.asList(X_FORWARDED_USER,
             X_FORWARDED_PREFERRED_USERNAME, X_FORWARDED_EMAIL, X_FORWARDED_ACCESS_TOKEN, X_FORWARDED_GROUPS));

--- a/src/main/java/com/github/tumbl3w33d/users/db/OAuth2ProxyUser.java
+++ b/src/main/java/com/github/tumbl3w33d/users/db/OAuth2ProxyUser.java
@@ -131,27 +131,39 @@ public class OAuth2ProxyUser extends AbstractEntity implements Comparable<OAuth2
 
     private static Optional<String[]> getNameParts(String preferredUsername) {
         String[] ret = new String[2];
-
-        if (preferredUsername == null) {
-            logger.debug("unable to extract name parts from null input as preferredUsername");
-            return Optional.empty();
+    
+        if (preferredUsername == null || preferredUsername.trim().isEmpty()) {
+            logger.debug("unable to extract name parts from null or empty input as preferredUsername");
+            ret[0] = "Unknown";
+            ret[1] = "Unknown";
+            return Optional.of(ret);
         }
 
-        // naive approach to figure out names from username
-        if (preferredUsername.contains(".")) {
-            String[] name_parts = preferredUsername.split("\\.");
-
-            try {
-                String assumed_firstname = name_parts[0].substring(0, 1).toUpperCase() + name_parts[0].substring(1);
-                ret[0] = assumed_firstname;
-                String assumed_lastname = name_parts[1].substring(0, 1).toUpperCase() + name_parts[1].substring(1);
-                ret[1] = assumed_lastname;
-                return Optional.of(ret);
-            } catch (IndexOutOfBoundsException e) {
-                logger.debug("preferred username in unexpected format - " + preferredUsername);
-            }
+        String localPart = preferredUsername.contains("@") 
+            ? preferredUsername.split("@")[0] 
+            : preferredUsername;
+    
+        String[] name_parts = localPart.split("\\.");
+    
+        if (name_parts.length == 0) {
+            logger.debug("preferred username in unexpected format (no name parts) - " + preferredUsername);
+            ret[0] = "Unknown";
+            ret[1] = "Unknown";
+        } else if (name_parts.length == 1) {
+            ret[0] = capitalize(name_parts[0]);
+            ret[1] = "Unknown";
+        } else {
+            ret[0] = capitalize(name_parts[0]);
+            ret[1] = capitalize(name_parts[name_parts.length - 1]);
         }
-        return Optional.empty();
+    
+        return Optional.of(ret);
+    }
+    
+    private static String capitalize(String s) {
+        return (s == null || s.isEmpty()) 
+            ? "Unknown" 
+            : s.substring(0, 1).toUpperCase() + s.substring(1).toLowerCase();
     }
 
     public String getGroupString() {


### PR DESCRIPTION
This introduces 5 environment variables, that can be used to configure headers containing user info.

```
OAUTH2_PROXY_HEADER_USER (default: X-Forwarded-User)
OAUTH2_PROXY_HEADER_PREFERRED_USERNAME (default: X-Forwarded-Preferred-Username)
OAUTH2_PROXY_HEADER_EMAIL (default: X-Forwarded-Email)
OAUTH2_PROXY_HEADER_ACCESS_TOKEN (default: X-Forwarded-Access-Token)
OAUTH2_PROXY_HEADER_GROUPS (default: X-Forwarded-Groups)
```

Second commit improves parsing of first name and surname from the username.